### PR TITLE
feat: hev-socks5-tunnel on x86_64, tun2socks fallback for aarch64

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License](https://img.shields.io/github/license/MrTheory/pfsense-xray)](LICENSE)
 [![pfSense](https://img.shields.io/badge/pfSense-CE%202.7.x%20%2F%202.8.x-blue)](https://www.pfsense.org)
-[![FreeBSD](https://img.shields.io/badge/FreeBSD-14.x%20amd64-red)](https://freebsd.org)
+[![FreeBSD](https://img.shields.io/badge/FreeBSD-14.x%20amd64%20%2F%20aarch64-red)](https://freebsd.org)
 [![PHP](https://img.shields.io/badge/PHP-8.2-purple)](https://php.net)
 
 **Xray-core VPN package for pfSense CE** — native GUI integration for VLESS+Reality tunnels with selective routing via pfSense Aliases and Firewall Rules.
@@ -18,12 +18,14 @@ Ported from [os-xray](https://github.com/MrTheory/os-xray) (OPNsense plugin). Al
 ```
 xray-core  (VLESS+Reality outbound)
     ↓  SOCKS5  (127.0.0.1:10808, configurable)
-tun2socks
+hev-socks5-tunnel  (amd64)  /  tun2socks  (aarch64 fallback)
     ↓  TUN interface  (e.g. proxytun0)
 pfSense Gateway  →  Firewall Rules  →  Selective routing
 ```
 
 Traffic you want to tunnel is sent to the Xray gateway via pfSense policy-based routing — no changes to xray-core routing config are needed. Aliases and firewall rules work natively.
+
+On **amd64**, [hev-socks5-tunnel](https://github.com/heiher/hev-socks5-tunnel) is used as the TUN bridge (~311 KB C binary). On **aarch64** (no hev release available), [tun2socks](https://github.com/xjasonlyu/tun2socks) is used as a fallback. The backend can be forced with `--backend` regardless of architecture.
 
 ---
 
@@ -57,10 +59,11 @@ Traffic you want to tunnel is sent to the Xray gateway via pfSense policy-based 
 | pfSense CE | 2.7.x / 2.8.x               |
 | FreeBSD    | 14.x amd64 / aarch64        |
 | PHP        | 8.2                         |
-| xray-core  | 24.x or later (recommended) |
-| tun2socks  | 2.x                         |
+| xray-core          | 24.x or later (recommended)     |
+| hev-socks5-tunnel  | 2.x (amd64)                     |
+| tun2socks          | 2.x (aarch64 fallback)          |
 
-> **Architecture note:** `install.sh` auto-detects `amd64` and `aarch64`. Other architectures are not supported by the upstream binaries.
+> **Architecture note:** `install.sh` auto-detects `amd64` and `aarch64`. On amd64, `hev-socks5-tunnel` is used by default; on aarch64, `tun2socks` is used. Use `--backend` to override.
 
 ---
 
@@ -84,8 +87,8 @@ sh install.sh
 
 The script will:
 
-- Download `xray-core` and `tun2socks` from GitHub Releases via `fetch`
-- Install binaries to `/usr/local/bin/xray-core` and `/usr/local/tun2socks/tun2socks`
+- Download `xray-core` and `hev-socks5-tunnel` (amd64) or `tun2socks` (aarch64) from GitHub Releases via `fetch`
+- Install binaries to `/usr/local/bin/xray-core` and `/usr/local/tun2socks/`
 - Copy all package files to the correct pfSense filesystem locations
 - Load the `if_tun` kernel module
 - Configure log rotation (`/etc/newsyslog.conf.d/xray.conf`)
@@ -113,7 +116,11 @@ sh install.sh update --no-binaries
 sh install.sh download-binaries
 
 # Pin specific versions
-sh install.sh --xray-version 25.4.30 --t2s-version 2.5.2
+sh install.sh --xray-version 25.4.30 --hev-version 2.14.4 --t2s-version 2.5.2
+
+# Force a specific tunnel backend (overrides arch detection)
+sh install.sh download-binaries --backend tun2socks
+sh install.sh download-binaries --backend hev
 
 # Full uninstall (stops services, removes files, cleans pfSense config)
 sh install.sh uninstall
@@ -278,12 +285,13 @@ All runtime files are named by instance UUID to avoid conflicts between instance
 | --------------------------------------------- | ----------------------------------------------------- |
 | `/usr/local/etc/xray-core/config-{uuid}.json` | xray-core config                                      |
 | `/usr/local/etc/xray-core/connections.json`   | Connections store (all groups)                        |
-| `/usr/local/tun2socks/config-{uuid}.yaml`     | tun2socks config                                      |
+| `/usr/local/tun2socks/config-{uuid}.yaml`     | tunnel bridge config (hev or tun2socks format)        |
+| `/usr/local/tun2socks/backend.txt`            | active backend: `hev` or `tun2socks`                  |
 | `/var/run/xray_core_{uuid}.pid`               | xray-core PID                                         |
-| `/var/run/tun2socks_{uuid}.pid`               | tun2socks PID                                         |
+| `/var/run/tunnel_{uuid}.pid`                  | tunnel bridge PID (hev-socks5-tunnel or tun2socks)    |
 | `/var/run/xray_start_{uuid}.lock`             | Per-instance startup lock (flock)                     |
 | `/var/run/xray_stopped_{uuid}.flag`           | Manual stop marker (watchdog skips)                   |
-| `/var/log/xray-core.log`                      | xray-core + tun2socks stderr output                   |
+| `/var/log/xray-core.log`                      | xray-core + tunnel bridge stderr output               |
 | `/var/log/xray-watchdog.log`                  | Watchdog restart events + subscription autoupdate log |
 
 ---
@@ -310,8 +318,11 @@ php /usr/local/scripts/xray/xray-service-control.php start <uuid>
 kldstat | grep if_tun
 kldload if_tun
 
-# Check tun2socks is running
-ps aux | grep tun2socks
+# Check which tunnel backend is active
+cat /usr/local/tun2socks/backend.txt
+
+# Check tunnel process is running
+ps aux | grep -E 'hev-socks5|tun2socks'
 
 # Check interface
 ifconfig proxytun0
@@ -319,7 +330,7 @@ ifconfig proxytun0
 
 **Gateway is marked down**
 
-Make sure **Monitor IP** is set to the local TUN peer address (e.g. `10.100.66.45`), not an external IP. tun2socks does not forward ICMP, so pinging external IPs through the gateway will always fail.
+Make sure **Monitor IP** is set to the gateway peer address (e.g. `10.100.66.45`), not an external IP. The tunnel bridge does not forward ICMP, so pinging external IPs through the gateway will always fail.
 
 **Traffic not routing through tunnel**
 
@@ -344,7 +355,8 @@ tail -100 /var/log/xray-core.log
 ## Credits
 
 - [Xray-core](https://github.com/XTLS/Xray-core) — the proxy engine
-- [tun2socks](https://github.com/xjasonlyu/tun2socks) — SOCKS5 to TUN bridge
+- [hev-socks5-tunnel](https://github.com/heiher/hev-socks5-tunnel) — lightweight SOCKS5 to TUN bridge (amd64)
+- [tun2socks](https://github.com/xjasonlyu/tun2socks) — SOCKS5 to TUN bridge (aarch64 fallback)
 - [os-xray](https://github.com/MrTheory/os-xray) — OPNsense plugin this is ported from
 
 ---

--- a/files/usr/local/pkg/xray.inc
+++ b/files/usr/local/pkg/xray.inc
@@ -246,6 +246,7 @@ function xray_deinstall(): void
 
     $patterns = [
         '/var/run/xray_core_*.pid',
+        '/var/run/tunnel_*.pid',
         '/var/run/tun2socks_*.pid',
         '/var/run/xray_start_*.lock',
         '/var/run/xray_stopped_*.flag',

--- a/files/usr/local/pkg/xray/includes/xray.inc
+++ b/files/usr/local/pkg/xray/includes/xray.inc
@@ -657,6 +657,7 @@ function xray_deinstall(): void
 
     $patterns = [
         '/var/run/xray_core_*.pid',
+        '/var/run/tunnel_*.pid',
         '/var/run/tun2socks_*.pid',
         '/var/run/xray_start_*.lock',
         '/var/run/xray_stopped_*.flag',

--- a/files/usr/local/scripts/xray/xray-ifstats.php
+++ b/files/usr/local/scripts/xray/xray-ifstats.php
@@ -45,7 +45,7 @@ if ($inst === null) {
 
 $tunIface  = $inst['tun_interface'] ?? 'proxytun0';
 $xrayPid   = "/var/run/xray_core_{$inst_uuid}.pid";
-$t2sPid    = "/var/run/tun2socks_{$inst_uuid}.pid";
+$t2sPid    = "/var/run/tunnel_{$inst_uuid}.pid";
 
 $serverAddr = '';
 $connUuid   = $inst['connection_uuid'] ?? ($inst['active_connection_uuid'] ?? '');
@@ -139,7 +139,7 @@ $pktsOut   = 0;
 $mtu       = 0;
 
 if ($ifRc === 0) {
-    if (preg_match('/inet\s+(\S+)\s+netmask\s+(\S+)/', $ifconfig, $m)) {
+    if (preg_match('/inet\s+(\S+)(?:\s+-->\s+\S+)?\s+netmask\s+(\S+)/', $ifconfig, $m)) {
         $tunIp  = $m[1];
         $hexMask = $m[2];
         if (str_starts_with($hexMask, '0x')) {

--- a/files/usr/local/scripts/xray/xray-service-control.php
+++ b/files/usr/local/scripts/xray/xray-service-control.php
@@ -64,6 +64,11 @@ function t2s_pid_path(string $inst_uuid): string
     return "/var/run/tunnel_{$inst_uuid}.pid";
 }
 
+function t2s_legacy_pid_path(string $inst_uuid): string
+{
+    return "/var/run/tun2socks_{$inst_uuid}.pid";
+}
+
 function xray_lock_path(string $inst_uuid): string
 {
     return "/var/run/xray_start_{$inst_uuid}.lock";
@@ -618,6 +623,7 @@ function do_stop(string $inst_uuid, ?string $tunIface = null): void
     }
 
     proc_kill(t2s_pid_path($inst_uuid));
+    proc_kill(t2s_legacy_pid_path($inst_uuid));
     proc_kill(xray_pid_path($inst_uuid));
     tun_destroy($tunIface);
 
@@ -711,7 +717,9 @@ function do_start(array $c): bool
             proc_start(XRAY_BIN, 'run -c ' . escapeshellarg(xray_conf_path($inst_uuid)), xray_pid_path($inst_uuid));
             usleep(800000);
         }
-        if (!proc_is_running(t2s_pid_path($inst_uuid))) {
+        $tunnelAlive = proc_is_running(t2s_pid_path($inst_uuid))
+            || proc_is_running(t2s_legacy_pid_path($inst_uuid));
+        if (!$tunnelAlive) {
             $tunnelArgs = tunnel_backend() === 'hev'
                 ? escapeshellarg(t2s_conf_path($inst_uuid))
                 : '-config ' . escapeshellarg(t2s_conf_path($inst_uuid));
@@ -732,7 +740,8 @@ function do_status(string $inst_uuid = ''): void
 {
     if ($inst_uuid !== '') {
         $xray = proc_is_running(xray_pid_path($inst_uuid));
-        $t2s  = proc_is_running(t2s_pid_path($inst_uuid));
+        $t2s  = proc_is_running(t2s_pid_path($inst_uuid))
+             || proc_is_running(t2s_legacy_pid_path($inst_uuid));
         echo json_encode([
             'status'    => ($xray && $t2s) ? 'ok' : 'stopped',
             'xray_core' => $xray ? 'running' : 'stopped',
@@ -750,7 +759,8 @@ function do_status(string $inst_uuid = ''): void
     $first = reset($all);
     $uuid0 = $first['inst_uuid'];
     $xray  = proc_is_running(xray_pid_path($uuid0));
-    $t2s   = proc_is_running(t2s_pid_path($uuid0));
+    $t2s   = proc_is_running(t2s_pid_path($uuid0))
+          || proc_is_running(t2s_legacy_pid_path($uuid0));
     echo json_encode([
         'status'    => ($xray && $t2s) ? 'ok' : 'stopped',
         'xray_core' => $xray ? 'running' : 'stopped',
@@ -764,7 +774,8 @@ function do_status_all(): void
     $result = [];
     foreach ($all as $inst_uuid => $c) {
         $xray = proc_is_running(xray_pid_path($inst_uuid));
-        $t2s  = proc_is_running(t2s_pid_path($inst_uuid));
+        $t2s  = proc_is_running(t2s_pid_path($inst_uuid))
+             || proc_is_running(t2s_legacy_pid_path($inst_uuid));
         $result[$inst_uuid] = [
             'name'      => $c['name'],
             'status'    => ($xray && $t2s) ? 'ok' : 'stopped',

--- a/files/usr/local/scripts/xray/xray-service-control.php
+++ b/files/usr/local/scripts/xray/xray-service-control.php
@@ -14,7 +14,7 @@ require_once('/usr/local/pkg/xray/includes/xray_connections.inc');
 // ─── Shared constants ─────────────────────────────────────────────────────────
 define('XRAY_BIN',          '/usr/local/bin/xray-core');
 define('XRAY_CONF_DIR',     '/usr/local/etc/xray-core');
-define('T2S_BIN',           '/usr/local/tun2socks/tun2socks');
+define('T2S_DIR',           '/usr/local/tun2socks');
 define('T2S_CONF_DIR',      '/usr/local/tun2socks');
 define('XRAY_DAEMON_LOG',   '/var/log/xray-core.log');
 define('XRAY_VERSION_FILE', '/usr/local/etc/xray-core/version.txt');
@@ -22,6 +22,26 @@ if (!defined('XRAY_DEFAULT_GROUP_UUID')) {
     define('XRAY_DEFAULT_GROUP_UUID', '00000000-0000-4000-8000-000000000001');
 }
 define('XRAY_ROTATION_SCRIPT', '/usr/local/scripts/xray/xray-rotation.php');
+
+function tunnel_backend(): string
+{
+    $backendFile = T2S_DIR . '/backend.txt';
+    if (file_exists($backendFile)) {
+        $backend = trim((string)file_get_contents($backendFile));
+        if ($backend === 'hev' || $backend === 'tun2socks') {
+            return $backend;
+        }
+    }
+    return file_exists(T2S_DIR . '/hev-socks5-tunnel') ? 'hev' : 'tun2socks';
+}
+
+function tunnel_bin(): string
+{
+    return tunnel_backend() === 'hev'
+        ? T2S_DIR . '/hev-socks5-tunnel'
+        : T2S_DIR . '/tun2socks';
+}
+
 
 // ─── Per-instance path functions ─────────────────────────────────────────────
 function xray_conf_path(string $inst_uuid): string
@@ -41,7 +61,7 @@ function t2s_conf_path(string $inst_uuid): string
 
 function t2s_pid_path(string $inst_uuid): string
 {
-    return "/var/run/tun2socks_{$inst_uuid}.pid";
+    return "/var/run/tunnel_{$inst_uuid}.pid";
 }
 
 function xray_lock_path(string $inst_uuid): string
@@ -305,16 +325,48 @@ function xray_write_config(array $c): void
     chmod($confFile, 0640);
 }
 
+function xray_tun_ip_for_uuid(string $uuid): string
+{
+    $crc    = crc32($uuid) & 0xFFFF;
+    $octet  = ($crc % 62) + 1;
+    $block  = ($crc >> 6) % 254 + 1;
+    return "10.100.{$block}.{$octet}";
+}
+
+function xray_tun_gw_for_uuid(string $uuid): string
+{
+    $crc    = crc32($uuid) & 0xFFFF;
+    $octet  = ($crc % 62) + 1;
+    $block  = ($crc >> 6) % 254 + 1;
+    return "10.100.{$block}." . ($octet - 1);
+}
+
 function t2s_write_config(array $c): void
 {
     if (!is_dir(T2S_CONF_DIR)) {
         mkdir(T2S_CONF_DIR, 0750, true);
     }
     $inst_uuid = $c['inst_uuid'];
-    $yaml = "proxy: socks5://{$c['socks5_listen']}:{$c['socks5_port']}\n"
-          . "device: {$c['tun_iface']}\n"
-          . "mtu: {$c['mtu']}\n"
-          . "loglevel: info\n";
+    if (tunnel_backend() === 'hev') {
+        $yaml = "tunnel:\n"
+              . "  name: {$c['tun_iface']}\n"
+              . "  mtu: {$c['mtu']}\n"
+              . "\n"
+              . "socks5:\n"
+              . "  address: {$c['socks5_listen']}\n"
+              . "  port: {$c['socks5_port']}\n"
+              . "  udp: udp\n"
+              . "\n"
+              . "misc:\n"
+              . "  log-file: stderr\n"
+              . "  log-level: warn\n"
+              . "  pid-file: " . t2s_pid_path($inst_uuid) . "\n";
+    } else {
+        $yaml = "proxy: socks5://{$c['socks5_listen']}:{$c['socks5_port']}\n"
+              . "device: {$c['tun_iface']}\n"
+              . "mtu: {$c['mtu']}\n"
+              . "loglevel: info\n";
+    }
     file_put_contents(t2s_conf_path($inst_uuid), $yaml);
     chmod(t2s_conf_path($inst_uuid), 0640);
 }
@@ -341,7 +393,7 @@ function proc_kill(string $pidfile): void
     $pid = (int)trim(file_get_contents($pidfile));
     if ($pid > 0) {
         $comm = trim((string)shell_exec('ps -o comm= -p ' . $pid . ' 2>/dev/null'));
-        if ($comm === '' || (strpos($comm, 'xray') === false && strpos($comm, 'tun2socks') === false)) {
+        if ($comm === '' || (strpos($comm, 'xray') === false && strpos($comm, 'tun2socks') === false && strpos($comm, 'hev-socks5') === false)) {
             @unlink($pidfile);
             return;
         }
@@ -428,6 +480,36 @@ function lo0_needs_alias(string $addr): bool
     return count($parts) === 4 && $parts[0] === '127';
 }
 
+function lo0_alias_ensure_any(string $addr): void
+{
+    exec('/sbin/ifconfig lo0 2>/dev/null', $out, $rc);
+    if ($rc !== 0) {
+        return;
+    }
+    if (strpos(implode("\n", $out), $addr) !== false) {
+        return;
+    }
+    exec('/sbin/ifconfig lo0 alias ' . escapeshellarg($addr) . ' netmask 255.255.255.255 2>/dev/null', $out2, $rc2);
+    if ($rc2 === 0) {
+        echo "INFO: Added lo0 alias {$addr}\n";
+    }
+}
+
+function lo0_alias_remove_any(string $addr): void
+{
+    exec('/sbin/ifconfig lo0 2>/dev/null', $out, $rc);
+    if ($rc !== 0) {
+        return;
+    }
+    if (strpos(implode("\n", $out), $addr) === false) {
+        return;
+    }
+    exec('/sbin/ifconfig lo0 -alias ' . escapeshellarg($addr) . ' 2>/dev/null', $out2, $rc2);
+    if ($rc2 === 0) {
+        echo "INFO: Removed lo0 alias {$addr}\n";
+    }
+}
+
 function lo0_alias_ensure(string $addr): void
 {
     if (!lo0_needs_alias($addr)) {
@@ -482,9 +564,20 @@ function xray_configure_tun(array $c): void
 
     exec('/sbin/ifconfig ' . escapeshellarg($iface) . ' mtu ' . $mtu . ' up 2>/dev/null');
 
-    $ip = xray_get_tun_ip_from_pfsense_config($iface);
-    if ($ip !== '') {
-        exec('/sbin/ifconfig ' . escapeshellarg($iface) . ' inet ' . escapeshellarg($ip) . ' 2>/dev/null');
+    $localIp = xray_tun_ip_for_uuid($c['inst_uuid']);
+    $gwIp    = xray_tun_gw_for_uuid($c['inst_uuid']);
+
+    if (tunnel_backend() === 'hev') {
+        exec('/sbin/ifconfig ' . escapeshellarg($iface)
+            . ' inet ' . escapeshellarg($gwIp)
+            . ' ' . escapeshellarg($gwIp)
+            . ' netmask 255.255.255.255 2>/dev/null');
+        lo0_alias_ensure_any($localIp);
+    } else {
+        exec('/sbin/ifconfig ' . escapeshellarg($iface)
+            . ' inet ' . escapeshellarg($localIp)
+            . ' ' . escapeshellarg($gwIp)
+            . ' netmask 255.255.255.255 2>/dev/null');
     }
 
     echo "INFO: TUN interface {$iface} configured\n";
@@ -526,9 +619,13 @@ function do_stop(string $inst_uuid, ?string $tunIface = null): void
 
     proc_kill(t2s_pid_path($inst_uuid));
     proc_kill(xray_pid_path($inst_uuid));
+    tun_destroy($tunIface);
 
     $c2 = xray_get_config($inst_uuid);
     lo0_alias_remove($c2['socks5_listen'] ?? '127.0.0.1');
+    if (tunnel_backend() === 'hev') {
+        lo0_alias_remove_any(xray_tun_ip_for_uuid($inst_uuid));
+    }
 
     file_put_contents(xray_stopped_flag($inst_uuid), date('Y-m-d H:i:s'));
 
@@ -541,8 +638,8 @@ function do_start(array $c): bool
         echo "ERROR: xray-core not found at " . XRAY_BIN . "\n";
         return false;
     }
-    if (!file_exists(T2S_BIN)) {
-        echo "ERROR: tun2socks not found at " . T2S_BIN . "\n";
+    if (!file_exists(tunnel_bin())) {
+        echo "ERROR: tunnel binary not found at " . tunnel_bin() . "\n";
         return false;
     }
 
@@ -615,7 +712,10 @@ function do_start(array $c): bool
             usleep(800000);
         }
         if (!proc_is_running(t2s_pid_path($inst_uuid))) {
-            proc_start(T2S_BIN, '-config ' . escapeshellarg(t2s_conf_path($inst_uuid)), t2s_pid_path($inst_uuid));
+            $tunnelArgs = tunnel_backend() === 'hev'
+                ? escapeshellarg(t2s_conf_path($inst_uuid))
+                : '-config ' . escapeshellarg(t2s_conf_path($inst_uuid));
+            proc_start(tunnel_bin(), $tunnelArgs, t2s_pid_path($inst_uuid));
             usleep(800000);
         }
 

--- a/files/usr/local/scripts/xray/xray-watchdog.php
+++ b/files/usr/local/scripts/xray/xray-watchdog.php
@@ -7,7 +7,7 @@
  * Runs every minute via cron. For each instance:
  *   1. Checks watchdog_enabled global flag.
  *   2. Skips instances with xray_stopped_<uuid>.flag (manual stop).
- *   3. If xray-core OR tun2socks died — triggers restart.
+ *   3. If xray-core OR tunnel process died — triggers restart.
  */
 
 set_include_path('/etc/inc' . PATH_SEPARATOR . '/usr/local/share/pear' . PATH_SEPARATOR . get_include_path());
@@ -75,7 +75,7 @@ foreach ($instancesCfg as $inst) {
     }
 
     $xrayPid = "/var/run/xray_core_{$inst_uuid}.pid";
-    $t2sPid  = "/var/run/tun2socks_{$inst_uuid}.pid";
+    $t2sPid  = "/var/run/tunnel_{$inst_uuid}.pid";
 
     $xrayAlive = proc_alive($xrayPid);
     $t2sAlive  = proc_alive($t2sPid);
@@ -89,7 +89,7 @@ foreach ($instancesCfg as $inst) {
         $died[] = 'xray-core';
     }
     if (!$t2sAlive) {
-        $died[] = 'tun2socks';
+        $died[] = 'tunnel';
     }
 
     wlog("WATCHDOG [{$name}]: " . implode(', ', $died) . " not running — triggering restart");

--- a/files/usr/local/www/xray/xray_diagnostics.php
+++ b/files/usr/local/www/xray/xray_diagnostics.php
@@ -166,7 +166,7 @@ events.push(function() {
             ['<?= gettext('Packets In') ?>',       data.pkts_in || '&mdash;'],
             ['<?= gettext('Packets Out') ?>',      data.pkts_out || '&mdash;'],
             ['<?= gettext('xray-core Uptime') ?>', data.xray_uptime || '&mdash;'],
-            ['<?= gettext('tun2socks Uptime') ?>', data.tun2socks_uptime || '&mdash;'],
+            ['<?= gettext('Tunnel Uptime') ?>', data.tun2socks_uptime || '&mdash;'],
             ['<?= gettext('Server') ?>',           data.server_address || '&mdash;'],
         ];
 

--- a/files/usr/local/www/xray/xray_settings.php
+++ b/files/usr/local/www/xray/xray_settings.php
@@ -71,7 +71,7 @@ $section->addInput(new Form_Checkbox(
 	gettext('Watchdog'),
 	gettext('Enable crash watchdog'),
 	($pconfig['watchdog_enabled'] ?? '') === 'on'
-))->setHelp(gettext('Automatically restart crashed xray-core or tun2socks processes (runs every minute via cron).'));
+))->setHelp(gettext('Automatically restart crashed xray-core or tunnel processes (runs every minute via cron).'));
 
 $section->addInput(new Form_Input(
 	'test_url',

--- a/install.sh
+++ b/install.sh
@@ -11,11 +11,13 @@
 #   install              Full install (default)
 #   update               Re-deploy files + restart services
 #   uninstall            Stop services, remove files, clean config
-#   download-binaries    Download xray-core + tun2socks only
+#   download-binaries    Download xray-core + tunnel binaries only
 #
 # Options:
 #   --xray-version VER   xray-core version (default: 25.4.30)
-#   --t2s-version VER    tun2socks version (default: 2.5.2)
+#   --hev-version VER    hev-socks5-tunnel version (default: 2.14.4, x86_64 only)
+#   --t2s-version VER    tun2socks version (default: 2.5.2, aarch64 fallback)
+#   --backend BACKEND    Force tunnel backend: 'hev' or 'tun2socks' (overrides arch detection)
 #   --no-binaries        Skip binary download (use existing)
 
 set -e
@@ -24,8 +26,10 @@ set -u
 # ─── Defaults ─────────────────────────────────────────────────────────────────
 COMMAND="install"
 XRAY_VERSION="25.4.30"
+HEV_VERSION="2.14.4"
 T2S_VERSION="2.5.2"
 SKIP_BINARIES=0
+FORCE_BACKEND=""
 
 # ─── Parse arguments ──────────────────────────────────────────────────────────
 while [ $# -gt 0 ]; do
@@ -38,8 +42,20 @@ while [ $# -gt 0 ]; do
             XRAY_VERSION="$2"
             shift 2
             ;;
+        --hev-version)
+            HEV_VERSION="$2"
+            shift 2
+            ;;
         --t2s-version)
             T2S_VERSION="$2"
+            shift 2
+            ;;
+        --backend)
+            FORCE_BACKEND="$2"
+            case "${FORCE_BACKEND}" in
+                hev|tun2socks) ;;
+                *) die "--backend must be 'hev' or 'tun2socks'" ;;
+            esac
             shift 2
             ;;
         --no-binaries)
@@ -68,8 +84,8 @@ fi
 # ─── Architecture detection ───────────────────────────────────────────────────
 ARCH=$(uname -m)
 case "${ARCH}" in
-    amd64)   XRAY_ARCH="64";        T2S_ARCH="amd64" ;;
-    aarch64) XRAY_ARCH="arm64-v8a"; T2S_ARCH="arm64" ;;
+    amd64)   XRAY_ARCH="64";        T2S_ARCH="amd64"; HEV_ARCH="x86_64" ;;
+    aarch64) XRAY_ARCH="arm64-v8a"; T2S_ARCH="arm64"; HEV_ARCH="" ;;
     *)       die "Unsupported architecture: ${ARCH}" ;;
 esac
 
@@ -100,25 +116,45 @@ cmd_download_binaries() {
     echo "${XRAY_VERSION}" > /usr/local/etc/xray-core/version.txt
     ok "xray-core $(/usr/local/bin/xray-core version 2>/dev/null | head -1)"
 
-    # tun2socks
-    T2S_URL="https://github.com/xjasonlyu/tun2socks/releases/download/v${T2S_VERSION}/tun2socks-freebsd-${T2S_ARCH}.zip"
-    info "Downloading tun2socks ${T2S_VERSION}..."
-    fetch -q -o "${TMPDIR}/tun2socks.zip" "${T2S_URL}" || die "Failed to download tun2socks"
+    # hev-socks5-tunnel (x86_64) or tun2socks fallback (aarch64)
+    # --backend flag overrides auto-detection
+    if [ "${FORCE_BACKEND}" = "tun2socks" ]; then
+        HEV_ARCH=""
+    elif [ "${FORCE_BACKEND}" = "hev" ] && [ -z "${HEV_ARCH}" ]; then
+        die "hev-socks5-tunnel has no binary for ${ARCH}"
+    fi
 
-    mkdir -p "${TMPDIR}/tun2socks"
-    unzip -q "${TMPDIR}/tun2socks.zip" -d "${TMPDIR}/tun2socks/" || die "Failed to unzip tun2socks"
+    if [ -n "${HEV_ARCH}" ]; then
+        HEV_URL="https://github.com/heiher/hev-socks5-tunnel/releases/download/${HEV_VERSION}/hev-socks5-tunnel-freebsd-${HEV_ARCH}"
+        info "Downloading hev-socks5-tunnel ${HEV_VERSION} (${HEV_ARCH})..."
+        fetch -q -o "${TMPDIR}/hev-socks5-tunnel" "${HEV_URL}" || die "Failed to download hev-socks5-tunnel"
+        install -m 755 "${TMPDIR}/hev-socks5-tunnel" /usr/local/tun2socks/hev-socks5-tunnel
+        rm -f /usr/local/tun2socks/tun2socks
+        echo "hev" > /usr/local/tun2socks/backend.txt
+        ok "hev-socks5-tunnel $(/usr/local/tun2socks/hev-socks5-tunnel --version 2>/dev/null | head -1)"
+    else
+        info "hev-socks5-tunnel has no ${ARCH} binary — using tun2socks fallback"
+        T2S_URL="https://github.com/xjasonlyu/tun2socks/releases/download/v${T2S_VERSION}/tun2socks-freebsd-${T2S_ARCH}.zip"
+        info "Downloading tun2socks ${T2S_VERSION}..."
+        fetch -q -o "${TMPDIR}/tun2socks.zip" "${T2S_URL}" || die "Failed to download tun2socks"
 
-    T2S_BIN=""
-    for candidate in "${TMPDIR}/tun2socks/tun2socks" "${TMPDIR}/tun2socks/tun2socks-freebsd-${T2S_ARCH}"; do
-        if [ -f "${candidate}" ]; then
-            T2S_BIN="${candidate}"
-            break
-        fi
-    done
-    [ -z "${T2S_BIN}" ] && die "tun2socks binary not found in archive"
+        mkdir -p "${TMPDIR}/tun2socks"
+        unzip -q "${TMPDIR}/tun2socks.zip" -d "${TMPDIR}/tun2socks/" || die "Failed to unzip tun2socks"
 
-    install -m 755 "${T2S_BIN}" /usr/local/tun2socks/tun2socks
-    ok "tun2socks $(/usr/local/tun2socks/tun2socks --version 2>/dev/null | head -1)"
+        T2S_BIN=""
+        for candidate in "${TMPDIR}/tun2socks/tun2socks" "${TMPDIR}/tun2socks/tun2socks-freebsd-${T2S_ARCH}"; do
+            if [ -f "${candidate}" ]; then
+                T2S_BIN="${candidate}"
+                break
+            fi
+        done
+        [ -z "${T2S_BIN}" ] && die "tun2socks binary not found in archive"
+
+        install -m 755 "${T2S_BIN}" /usr/local/tun2socks/tun2socks
+        rm -f /usr/local/tun2socks/hev-socks5-tunnel
+        echo "tun2socks" > /usr/local/tun2socks/backend.txt
+        ok "tun2socks $(/usr/local/tun2socks/tun2socks --version 2>/dev/null | head -1)"
+    fi
 }
 
 # ─── Deploy package files from repo ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Replaces tun2socks with [hev-socks5-tunnel](https://github.com/heiher/hev-socks5-tunnel) on amd64 (~311KB C binary vs ~10MB Go binary)
- aarch64 keeps tun2socks as fallback (no hev FreeBSD aarch64 release available)
- New `--backend hev|tun2socks` flag in `install.sh` to force a specific backend regardless of arch
- Both backends use deterministic IP assignment from UUID — no dependency on pfSense config for TUN IP
- Gateway monitoring works correctly: hev assigns gwIp on TUN + localIp as lo0 alias so dpinger responds via loopback
- `tun_destroy()` now called on stop so tun2socks/hev can recreate the interface on next start
- PID file renamed `tun2socks_UUID.pid` → `tunnel_UUID.pid`
- Fixed ifstats inet regex to handle P2P `inet X --> Y netmask Z` format
- README updated: architecture diagram, requirements, install examples, runtime files, troubleshooting

## Test plan

- [x] Install on amd64 pfSense 2.8.1 — hev-socks5-tunnel downloaded and used
- [x] Gateway XRAY_GW goes Online after instance start
- [x] Traffic routes through tunnel correctly
- [x] `sh install.sh download-binaries --backend tun2socks` switches to tun2socks, traffic works
- [x] `sh install.sh download-binaries --backend hev` switches back to hev, traffic works
- [x] Restart/stop/start cycle works cleanly (no "interface already exists" error)
- [x] TUN IP shown correctly on Diagnostics page