### PR TITLE
fix: standalone install, menu registration, config_mode and multi-instance fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![License](https://img.shields.io/github/license/pdazcom/pfSense-pkg-xray)](LICENSE)
 [![pfSense](https://img.shields.io/badge/pfSense-CE%202.7.x%20%2F%202.8.x-blue)](https://www.pfsense.org)
-[![FreeBSD](https://img.shields.io/badge/FreeBSD-14.x%20amd64%20%2F%20aarch64-red)](https://freebsd.org)
-[![PHP](https://img.shields.io/badge/PHP-8.2-purple)](https://php.net)
+[![FreeBSD](https://img.shields.io/badge/FreeBSD-14.x%20%2F%2015.x%20amd64%20%2F%20aarch64-red)](https://freebsd.org)
+[![PHP](https://img.shields.io/badge/PHP-8.2%20%2F%208.3-purple)](https://php.net)
 
 **Xray-core VPN package for pfSense CE** — native GUI integration for VLESS+Reality tunnels with selective routing via pfSense Aliases and Firewall Rules.
 
@@ -57,8 +57,8 @@ On **amd64**, [hev-socks5-tunnel](https://github.com/heiher/hev-socks5-tunnel) i
 | Component  | Version                     |
 | ---------- | --------------------------- |
 | pfSense CE | 2.7.x / 2.8.x               |
-| FreeBSD    | 14.x amd64 / aarch64        |
-| PHP        | 8.2                         |
+| FreeBSD    | 14.x / 15.x amd64 / aarch64 |
+| PHP        | 8.2 / 8.3                   |
 | xray-core          | 24.x or later (recommended)     |
 | hev-socks5-tunnel  | 2.x (amd64)                     |
 | tun2socks          | 2.x (aarch64 fallback)          |
@@ -241,7 +241,13 @@ sh install.sh update
 ## Uninstalling
 
 ```sh
-cd /tmp/pfsense-xray
+fetch -o /tmp/install.sh https://raw.githubusercontent.com/pdazcom/pfSense-pkg-xray/main/install.sh && sh /tmp/install.sh uninstall
+```
+
+Or, if installed via git clone:
+
+```sh
+cd /tmp/pfSense-pkg-xray
 sh install.sh uninstall
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pfSense-pkg-xray
 
-[![License](https://img.shields.io/github/license/MrTheory/pfsense-xray)](LICENSE)
+[![License](https://img.shields.io/github/license/pdazcom/pfSense-pkg-xray)](LICENSE)
 [![pfSense](https://img.shields.io/badge/pfSense-CE%202.7.x%20%2F%202.8.x-blue)](https://www.pfsense.org)
 [![FreeBSD](https://img.shields.io/badge/FreeBSD-14.x%20amd64%20%2F%20aarch64-red)](https://freebsd.org)
 [![PHP](https://img.shields.io/badge/PHP-8.2-purple)](https://php.net)
@@ -69,34 +69,43 @@ On **amd64**, [hev-socks5-tunnel](https://github.com/heiher/hev-socks5-tunnel) i
 
 ## Installation
 
-### Step 1 — Clone the repository on pfSense
+### One-line install (recommended)
 
 SSH into pfSense and run:
 
 ```sh
-cd /tmp
-git clone https://github.com/MrTheory/pfsense-xray.git
-cd pfsense-xray
+fetch -o /tmp/install.sh https://raw.githubusercontent.com/pdazcom/pfSense-pkg-xray/main/install.sh && sh /tmp/install.sh
 ```
 
-### Step 2 — Run install.sh
-
-```sh
-sh install.sh
-```
+> **Why `fetch` instead of `curl`?** pfSense/FreeBSD ships `fetch` by default. `curl` may not be available without installing it separately.
 
 The script will:
 
-- Download `xray-core` and `hev-socks5-tunnel` (amd64) or `tun2socks` (aarch64) from GitHub Releases via `fetch`
+- Download `xray-core` and `hev-socks5-tunnel` (amd64) or `tun2socks` (aarch64) from GitHub Releases
 - Install binaries to `/usr/local/bin/xray-core` and `/usr/local/tun2socks/`
 - Copy all package files to the correct pfSense filesystem locations
 - Load the `if_tun` kernel module
 - Configure log rotation (`/etc/newsyslog.conf.d/xray.conf`)
 - Register the package in pfSense (adds **VPN → Xray** menu)
 
-### Step 3 — Enable the package
+### Step 2 — Enable the package
 
 Open pfSense web UI → **VPN → Xray → Settings** → check **Enable Xray** → **Save**.
+
+---
+
+### Alternative: install via git clone
+
+If you prefer to have the full source available (e.g. for development or customization):
+
+```sh
+cd /tmp
+git clone https://github.com/pdazcom/pfSense-pkg-xray.git
+cd pfSense-pkg-xray
+sh install.sh
+```
+
+> `git` is not installed on pfSense by default. Install it first: **System → Package Manager → Available Packages** → search `git` → Install.
 
 ---
 
@@ -216,7 +225,13 @@ After starting an instance, configure pfSense to route selected traffic through 
 ## Updating
 
 ```sh
-cd /tmp/pfsense-xray
+fetch -o /tmp/install.sh https://raw.githubusercontent.com/pdazcom/pfSense-pkg-xray/main/install.sh && sh /tmp/install.sh update
+```
+
+Or, if installed via git clone:
+
+```sh
+cd /tmp/pfSense-pkg-xray
 git pull
 sh install.sh update
 ```

--- a/files/usr/local/pkg/xray/includes/xray.inc
+++ b/files/usr/local/pkg/xray/includes/xray.inc
@@ -745,6 +745,11 @@ function xray_deinstall(): void
     }
 
     xray_unregister_menu();
+
+    unset($config['installedpackages']['xray']);
+    unset($config['installedpackages']['xrayinstances']);
+    unset($config['installedpackages']['xraygroups']);
+    unset($config['installedpackages']['xrayconnections']);
 }
 
 function xray_unregister_menu(): void

--- a/files/usr/local/pkg/xray/includes/xray.inc
+++ b/files/usr/local/pkg/xray/includes/xray.inc
@@ -171,7 +171,8 @@ function xray_is_enabled(): bool
 function xray_get_instances(): array
 {
     global $config;
-    return $config['installedpackages']['xrayinstances']['config'] ?? [];
+    $list = $config['installedpackages']['xrayinstances']['config'] ?? [];
+    return is_array($list) ? $list : [];
 }
 
 function xray_get_instance_by_uuid(string $uuid): ?array
@@ -195,7 +196,10 @@ function xray_save_instance(array $instance): void
 {
     global $config;
 
-    if (!isset($config['installedpackages']['xrayinstances']['config'])) {
+    if (!is_array($config['installedpackages']['xrayinstances'] ?? null)) {
+        $config['installedpackages']['xrayinstances'] = [];
+    }
+    if (!is_array($config['installedpackages']['xrayinstances']['config'] ?? null)) {
         $config['installedpackages']['xrayinstances']['config'] = [];
     }
 
@@ -220,7 +224,7 @@ function xray_delete_instance(string $uuid): void
 {
     global $config;
 
-    if (!isset($config['installedpackages']['xrayinstances']['config'])) {
+    if (!is_array($config['installedpackages']['xrayinstances']['config'] ?? null)) {
         return;
     }
 
@@ -243,7 +247,8 @@ function xray_delete_instance(string $uuid): void
 function xray_get_groups(): array
 {
     global $config;
-    return $config['installedpackages']['xraygroups']['config'] ?? [];
+    $list = $config['installedpackages']['xraygroups']['config'] ?? [];
+    return is_array($list) ? $list : [];
 }
 
 function xray_get_group_by_uuid(string $uuid): ?array
@@ -260,7 +265,10 @@ function xray_save_group(array $group): void
 {
     global $config;
 
-    if (!isset($config['installedpackages']['xraygroups']['config'])) {
+    if (!is_array($config['installedpackages']['xraygroups'] ?? null)) {
+        $config['installedpackages']['xraygroups'] = [];
+    }
+    if (!is_array($config['installedpackages']['xraygroups']['config'] ?? null)) {
         $config['installedpackages']['xraygroups']['config'] = [];
     }
 
@@ -549,8 +557,7 @@ function xray_unregister_tun_interface_by_uuid(string $uuid): void
 
 function xray_resync(): void
 {
-    mwexec('/usr/local/bin/php /usr/local/scripts/xray/xray-service-control.php reconfigure');
-    filter_configure();
+    mwexec_bg('/usr/local/bin/php /usr/local/scripts/xray/xray-service-control.php reconfigure');
 }
 
 // ─── Install / Deinstall ─────────────────────────────────────────────────────
@@ -594,8 +601,77 @@ EOT;
         'root'
     );
 
+    xray_register_menu();
     xray_bootstrap_default_group();
     xray_migrate_instances_to_connections();
+}
+
+function xray_register_menu(): void
+{
+    global $config;
+
+    // pfSense XML serializer treats 'package', 'menu', 'service' as listtags —
+    // they must be flat arrays (not ['item' => [...]]).
+    // head.inc only renders menu entries when 'package' is also non-empty.
+    if (!is_array($config['installedpackages'] ?? null)) {
+        $config['installedpackages'] = [];
+    }
+    if (!is_array($config['installedpackages']['package'] ?? null)) {
+        $config['installedpackages']['package'] = [];
+    }
+    $packageExists = false;
+    foreach ($config['installedpackages']['package'] as $pkg) {
+        if (($pkg['name'] ?? '') === 'xray') {
+            $packageExists = true;
+            break;
+        }
+    }
+    if (!$packageExists) {
+        $config['installedpackages']['package'][] = [
+            'name'         => 'xray',
+            'version'      => '1.2.0',
+            'descr'        => 'Xray VPN (xray-core + tunnel)',
+            'include_file' => '/usr/local/pkg/xray/includes/xray.inc',
+        ];
+    }
+
+    if (!is_array($config['installedpackages']['menu'] ?? null)) {
+        $config['installedpackages']['menu'] = [];
+    }
+    $menuExists = false;
+    foreach ($config['installedpackages']['menu'] as $item) {
+        if (($item['name'] ?? '') === 'Xray') {
+            $menuExists = true;
+            break;
+        }
+    }
+    if (!$menuExists) {
+        $config['installedpackages']['menu'][] = [
+            'name'    => 'Xray',
+            'section' => 'VPN',
+            'url'     => '/xray/xray_connections.php',
+            'order'   => '',
+        ];
+    }
+
+    if (!is_array($config['installedpackages']['service'] ?? null)) {
+        $config['installedpackages']['service'] = [];
+    }
+    $serviceExists = false;
+    foreach ($config['installedpackages']['service'] as $svc) {
+        if (($svc['name'] ?? '') === 'xray') {
+            $serviceExists = true;
+            break;
+        }
+    }
+    if (!$serviceExists) {
+        $config['installedpackages']['service'][] = [
+            'name'        => 'xray',
+            'rcfile'      => 'xray',
+            'executable'  => 'xray-core',
+            'description' => 'Xray VPN (xray-core + tunnel)',
+        ];
+    }
 }
 
 function xray_bootstrap_default_group(): void
@@ -667,4 +743,35 @@ function xray_deinstall(): void
     foreach ($patterns as $pattern) {
         array_map('unlink', glob($pattern) ?: []);
     }
+
+    xray_unregister_menu();
+}
+
+function xray_unregister_menu(): void
+{
+    global $config;
+
+    $filtered = [];
+    foreach ($config['installedpackages']['package'] ?? [] as $pkg) {
+        if (($pkg['name'] ?? '') !== 'xray') {
+            $filtered[] = $pkg;
+        }
+    }
+    $config['installedpackages']['package'] = $filtered;
+
+    $filtered = [];
+    foreach ($config['installedpackages']['menu'] ?? [] as $item) {
+        if (($item['name'] ?? '') !== 'Xray') {
+            $filtered[] = $item;
+        }
+    }
+    $config['installedpackages']['menu'] = $filtered;
+
+    $filteredSvc = [];
+    foreach ($config['installedpackages']['service'] ?? [] as $svc) {
+        if (($svc['name'] ?? '') !== 'xray') {
+            $filteredSvc[] = $svc;
+        }
+    }
+    $config['installedpackages']['service'] = $filteredSvc;
 }

--- a/files/usr/local/scripts/xray/xray-ifstats.php
+++ b/files/usr/local/scripts/xray/xray-ifstats.php
@@ -47,25 +47,26 @@ $tunIface  = $inst['tun_interface'] ?? 'proxytun0';
 $xrayPid   = "/var/run/xray_core_{$inst_uuid}.pid";
 $t2sPid    = "/var/run/tunnel_{$inst_uuid}.pid";
 
-$serverAddr = '';
-$connUuid   = $inst['connection_uuid'] ?? ($inst['active_connection_uuid'] ?? '');
+$serverLabel = '';
+$serverHost  = '';
+$connUuid    = $inst['connection_uuid'] ?? ($inst['active_connection_uuid'] ?? '');
 if ($connUuid !== '') {
     $conn = xray_get_connection_by_uuid($connUuid);
     if ($conn !== null) {
-        $serverAddr = ifstats_server_label($conn);
+        [$serverHost, $serverLabel] = ifstats_server_parts($conn);
     }
 }
-if ($serverAddr === '') {
+if ($serverLabel === '') {
     $groupUuid = $inst['connection_group_uuid'] ?? '';
     if ($groupUuid !== '') {
         $groupConns = xray_get_connections_by_group($groupUuid);
         if (!empty($groupConns)) {
-            $serverAddr = ifstats_server_label($groupConns[0]);
+            [$serverHost, $serverLabel] = ifstats_server_parts($groupConns[0]);
         }
     }
 }
 
-function ifstats_server_label(array $conn): string
+function ifstats_server_parts(array $conn): array
 {
     $json = trim($conn['custom_config'] ?? '');
     if ($json !== '') {
@@ -73,14 +74,14 @@ function ifstats_server_label(array $conn): string
         $address = $decoded['outbounds'][0]['settings']['vnext'][0]['address'] ?? '';
         $port    = $decoded['outbounds'][0]['settings']['vnext'][0]['port']    ?? '';
         if ($address !== '') {
-            return $address . ':' . $port;
+            return [$address, $address . ':' . $port];
         }
     }
     $addr = trim($conn['server_address'] ?? '');
     if ($addr !== '') {
-        return $addr . ':' . ($conn['server_port'] ?? '443');
+        return [$addr, $addr . ':' . ($conn['server_port'] ?? '443')];
     }
-    return '';
+    return ['', ''];
 }
 
 // ─── Process uptime ───────────────────────────────────────────────────────────
@@ -214,8 +215,8 @@ $t2sUptimeSecs  = proc_uptime($t2sPid);
 
 // ─── Ping RTT to VPN server ───────────────────────────────────────────────────
 $pingRtt = 'N/A';
-if ($serverAddr !== '') {
-    exec('/sbin/ping -c 3 -W 2 ' . escapeshellarg($serverAddr) . ' 2>/dev/null', $pingOut, $pingRc);
+if ($serverHost !== '') {
+    exec('/sbin/ping -c 3 -W 2 ' . escapeshellarg($serverHost) . ' 2>/dev/null', $pingOut, $pingRc);
     if ($pingRc === 0) {
         $pingOutput = implode("\n", $pingOut);
         if (preg_match('/round-trip.+=\s*[\d.]+\/([\d.]+)\//', $pingOutput, $pm)) {
@@ -241,7 +242,7 @@ $result = [
     'xray_uptime_secs'      => $xrayUptimeSecs,
     'tun2socks_uptime'      => xray_format_uptime($t2sUptimeSecs),
     'tun2socks_uptime_secs' => $t2sUptimeSecs,
-    'server_address'        => $serverAddr,
+    'server_address'        => $serverLabel,
     'ping_rtt'              => $pingRtt,
 ];
 

--- a/files/usr/local/scripts/xray/xray-ifstats.php
+++ b/files/usr/local/scripts/xray/xray-ifstats.php
@@ -51,14 +51,36 @@ $serverAddr = '';
 $connUuid   = $inst['connection_uuid'] ?? ($inst['active_connection_uuid'] ?? '');
 if ($connUuid !== '') {
     $conn = xray_get_connection_by_uuid($connUuid);
-    $serverAddr = $conn['server_address'] ?? '';
+    if ($conn !== null) {
+        $serverAddr = ifstats_server_label($conn);
+    }
 }
 if ($serverAddr === '') {
     $groupUuid = $inst['connection_group_uuid'] ?? '';
     if ($groupUuid !== '') {
         $groupConns = xray_get_connections_by_group($groupUuid);
-        $serverAddr = $groupConns[0]['server_address'] ?? '';
+        if (!empty($groupConns)) {
+            $serverAddr = ifstats_server_label($groupConns[0]);
+        }
     }
+}
+
+function ifstats_server_label(array $conn): string
+{
+    $json = trim($conn['custom_config'] ?? '');
+    if ($json !== '') {
+        $decoded = json_decode($json, true);
+        $address = $decoded['outbounds'][0]['settings']['vnext'][0]['address'] ?? '';
+        $port    = $decoded['outbounds'][0]['settings']['vnext'][0]['port']    ?? '';
+        if ($address !== '') {
+            return $address . ':' . $port;
+        }
+    }
+    $addr = trim($conn['server_address'] ?? '');
+    if ($addr !== '') {
+        return $addr . ':' . ($conn['server_port'] ?? '443');
+    }
+    return '';
 }
 
 // ─── Process uptime ───────────────────────────────────────────────────────────

--- a/files/usr/local/scripts/xray/xray-rotation.php
+++ b/files/usr/local/scripts/xray/xray-rotation.php
@@ -135,7 +135,7 @@ function rotation_urltest(array $conn, string $testUrl): array
 
 function rotation_build_config(array $conn, int $socksPort): ?string
 {
-    $configMode = $conn['config_mode'] ?? 'wizard';
+    $configMode = trim($conn['custom_config'] ?? '') !== '' ? 'custom' : (($conn['config_mode'] ?? 'wizard') ?: 'wizard');
 
     if ($configMode === 'custom') {
         $raw = trim($conn['custom_config'] ?? '');

--- a/files/usr/local/scripts/xray/xray-service-control.php
+++ b/files/usr/local/scripts/xray/xray-service-control.php
@@ -152,7 +152,9 @@ function xray_parse_instance_array(array $inst, array $conn, bool $globalEnabled
         // mux
         'mux'                    => $conn['mux']                 ?? '',
         // config
-        'config_mode'            => ($conn['config_mode'] ?? 'wizard') ?: 'wizard',
+        'config_mode'            => trim($conn['custom_config'] ?? '') !== ''
+                                     ? 'custom'
+                                     : (($conn['config_mode'] ?? 'wizard') ?: 'wizard'),
         'custom_config'          => $conn['custom_config'] ?? '',
         'socks5_listen'          => ($inst['socks5_listen'] ?? '127.0.0.1') ?: '127.0.0.1',
         'socks5_port'            => (int)($inst['socks5_port'] ?? 10808) ?: 10808,
@@ -318,6 +320,17 @@ function xray_write_config(array $c): void
         if ($decoded === null) {
             echo "ERROR: custom_config is not valid JSON\n";
             return;
+        }
+        // Always override inbound port/listen from instance settings so that
+        // multiple instances using the same connection JSON don't collide.
+        if (isset($decoded['inbounds']) && is_array($decoded['inbounds'])) {
+            foreach ($decoded['inbounds'] as &$inbound) {
+                if (($inbound['tag'] ?? '') === 'socks-in' || ($inbound['protocol'] ?? '') === 'socks') {
+                    $inbound['port']   = (int)$c['socks5_port'];
+                    $inbound['listen'] = $c['socks5_listen'];
+                }
+            }
+            unset($inbound);
         }
         $json = json_encode($decoded, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
         $json = xray_normalize_transport($json);
@@ -801,9 +814,13 @@ switch ($action) {
     case 'start':
         if ($inst_uuid !== '') {
             $c = xray_get_config($inst_uuid);
-            if (empty($c) || !$c['enabled']) {
-                echo "Xray is disabled or instance not found.\n";
-                exit(0);
+            if (empty($c)) {
+                echo "ERROR: Instance not found.\n";
+                exit(1);
+            }
+            if (!$c['enabled']) {
+                echo "ERROR: Xray is disabled. Go to VPN → Xray → Settings and enable it first.\n";
+                exit(2);
             }
             $ok = do_start($c);
             exit($ok ? 0 : 1);

--- a/files/usr/local/scripts/xray/xray-urltest.inc
+++ b/files/usr/local/scripts/xray/xray-urltest.inc
@@ -13,7 +13,7 @@ define('URLTEST_DEFAULT_URL', 'https://www.google.com');
 
 function urltest_build_config(array $conn, int $socksPort): ?string
 {
-    $configMode = $conn['config_mode'] ?? 'wizard';
+    $configMode = trim($conn['custom_config'] ?? '') !== '' ? 'custom' : (($conn['config_mode'] ?? 'wizard') ?: 'wizard');
 
     if ($configMode === 'custom') {
         $raw     = trim($conn['custom_config'] ?? '');

--- a/files/usr/local/www/xray/xray_diagnostics.php
+++ b/files/usr/local/www/xray/xray_diagnostics.php
@@ -168,6 +168,7 @@ events.push(function() {
             ['<?= gettext('xray-core Uptime') ?>', data.xray_uptime || '&mdash;'],
             ['<?= gettext('Tunnel Uptime') ?>', data.tun2socks_uptime || '&mdash;'],
             ['<?= gettext('Server') ?>',           data.server_address || '&mdash;'],
+            ['<?= gettext('Ping RTT') ?>',         data.ping_rtt || '&mdash;'],
         ];
 
         var html = '';

--- a/files/usr/local/www/xray/xray_edit.php
+++ b/files/usr/local/www/xray/xray_edit.php
@@ -108,8 +108,9 @@ foreach ($allConnections as $conn) {
             break;
         }
     }
+    $serverLabel = xray_connection_server_label($conn);
     $label = ($groupName !== '' ? $groupName . ' / ' : '') . ($conn['name'] ?? '')
-        . ' (' . ($conn['server_address'] ?? '') . ':' . ($conn['server_port'] ?? '') . ')';
+        . ($serverLabel !== '' ? ' (' . $serverLabel . ')' : '');
     $connectionOptions[$conn['uuid']] = htmlspecialchars($label, ENT_QUOTES, 'UTF-8');
 }
 

--- a/files/usr/local/www/xray/xray_instances.php
+++ b/files/usr/local/www/xray/xray_instances.php
@@ -22,8 +22,8 @@ require_once('xray/includes/xray.inc');
 if ($_POST && isset($_POST['act']) && $_POST['act'] === 'delete') {
 	$delUuid = xray_sanitize_uuid($_POST['uuid'] ?? '');
 	if ($delUuid !== '') {
+		mwexec('/usr/local/bin/php /usr/local/scripts/xray/xray-service-control.php stop ' . escapeshellarg($delUuid));
 		xray_delete_instance($delUuid);
-		xray_resync();
 	}
 	header('Location: /xray/xray_instances.php');
 	exit;
@@ -53,10 +53,12 @@ function xray_instance_connection_label(array $inst, array $allConns, array $all
 	$connUuid = $inst['connection_uuid'] ?? '';
 	foreach ($allConns as $conn) {
 		if ($conn['uuid'] === $connUuid) {
-			$name = htmlspecialchars($conn['name'] ?? '', ENT_QUOTES, 'UTF-8');
-			$addr = htmlspecialchars($conn['server_address'] ?? '', ENT_QUOTES, 'UTF-8');
-			$port = (int)($conn['server_port'] ?? 443);
-			return $name . '<br><small class="text-muted"><code>' . $addr . ':' . $port . '</code></small>';
+			$name        = htmlspecialchars($conn['name'] ?? '', ENT_QUOTES, 'UTF-8');
+			$serverLabel = xray_connection_server_label($conn);
+			$serverHtml  = $serverLabel !== ''
+				? '<br><small class="text-muted"><code>' . htmlspecialchars($serverLabel, ENT_QUOTES, 'UTF-8') . '</code></small>'
+				: '';
+			return $name . $serverHtml;
 		}
 	}
 	return '<span class="text-muted">' . gettext('(none)') . '</span>';
@@ -174,6 +176,11 @@ events.push(function() {
 			type: 'post',
 			data: { action: action, uuid: uuid },
 			dataType: 'json',
+			success: function(data) {
+				if (data.result === 'failed' && data.output) {
+					alert(data.output);
+				}
+			},
 			complete: function() {
 				setTimeout(refreshStatus, 1500);
 			}

--- a/install.sh
+++ b/install.sh
@@ -75,10 +75,35 @@ ok()    { echo "    [OK] $*"; }
 die()   { echo "[ERROR] $*" >&2; exit 1; }
 
 REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+REPO_DOWNLOADED=0
 
 # ─── Verify we're running on pfSense ─────────────────────────────────────────
 if [ ! -f /etc/inc/config.inc ]; then
     die "This script must be run on pfSense (FreeBSD). /etc/inc/config.inc not found."
+fi
+
+# ─── Auto-fetch package files if running as standalone install.sh ─────────────
+# When the script is fetched directly (not from a git clone), the files/ tree
+# won't be present next to it.  Download and unpack the repository archive so
+# cmd_deploy_files has something to copy from.
+GITHUB_REPO="pdazcom/pfSense-pkg-xray"
+GITHUB_BRANCH="main"
+
+if [ ! -d "${REPO_ROOT}/files" ]; then
+    ARCHIVE_URL="https://github.com/${GITHUB_REPO}/archive/refs/heads/${GITHUB_BRANCH}.tar.gz"
+    ARCHIVE_TMP="/tmp/pfsense-pkg-xray-src-$$.tar.gz"
+    EXTRACT_DIR="/tmp/pfsense-pkg-xray-src-$$"
+
+    info "Package source not found locally — downloading from GitHub..."
+    fetch -q -o "${ARCHIVE_TMP}" "${ARCHIVE_URL}" || die "Failed to download package source from GitHub"
+
+    mkdir -p "${EXTRACT_DIR}"
+    tar -xzf "${ARCHIVE_TMP}" -C "${EXTRACT_DIR}" --strip-components=1 || die "Failed to extract package source"
+    rm -f "${ARCHIVE_TMP}"
+
+    REPO_ROOT="${EXTRACT_DIR}"
+    REPO_DOWNLOADED=1
+    ok "Package source downloaded"
 fi
 
 # ─── Architecture detection ───────────────────────────────────────────────────
@@ -209,15 +234,34 @@ EOF
 cmd_register_package() {
     info "Registering package in pfSense..."
 
-    php -r "
-set_include_path('/etc/inc' . PATH_SEPARATOR . '/usr/local/share/pear');
+    # On pfSense 2.8.1+ the DHCP service was moved to a package, so
+    # services.inc → services_dhcp.inc no longer exists in the base system.
+    # We stub it out in a temp directory placed first on the include path so
+    # the bootstrap chain completes on both 2.7.x and 2.8.x.
+    STUB_DIR="/tmp/xray-inc-stub-$$"
+    mkdir -p "${STUB_DIR}"
+    printf '<?php\n' > "${STUB_DIR}/services_dhcp.inc"
+
+    PHP_SCRIPT="/tmp/xray-register-$$.php"
+    cat > "${PHP_SCRIPT}" << 'PHPEOF'
+<?php
+set_include_path('/etc/inc' . PATH_SEPARATOR . '/usr/local/share/pear' . PATH_SEPARATOR . ini_get('include_path'));
 require_once('globals.inc');
 require_once('config.inc');
 require_once('/usr/local/pkg/xray/includes/xray.inc');
 xray_install();
 write_config('Xray: package installed');
-echo 'done';
-" || die "Failed to register package"
+echo 'done' . PHP_EOL;
+PHPEOF
+
+    if php -d "include_path=${STUB_DIR}:/etc/inc:/usr/local/share/pear" "${PHP_SCRIPT}"; then
+        rm -f "${PHP_SCRIPT}"
+        rm -rf "${STUB_DIR}"
+    else
+        rm -f "${PHP_SCRIPT}"
+        rm -rf "${STUB_DIR}"
+        die "Failed to register package"
+    fi
 
     ok "Package registered (VPN → Xray menu added)"
 }
@@ -235,15 +279,25 @@ cmd_stop_all() {
 cmd_deregister_package() {
     info "Removing package from pfSense config..."
 
-    php -r "
-set_include_path('/etc/inc' . PATH_SEPARATOR . '/usr/local/share/pear');
+    STUB_DIR="/tmp/xray-inc-stub-$$"
+    mkdir -p "${STUB_DIR}"
+    printf '<?php\n' > "${STUB_DIR}/services_dhcp.inc"
+
+    PHP_SCRIPT="/tmp/xray-deregister-$$.php"
+    cat > "${PHP_SCRIPT}" << 'PHPEOF'
+<?php
+set_include_path('/etc/inc' . PATH_SEPARATOR . '/usr/local/share/pear' . PATH_SEPARATOR . ini_get('include_path'));
 require_once('globals.inc');
 require_once('config.inc');
 require_once('/usr/local/pkg/xray/includes/xray.inc');
 xray_deinstall();
 write_config('Xray: package removed');
-echo 'done';
-" 2>/dev/null || true
+echo 'done' . PHP_EOL;
+PHPEOF
+
+    php -d "include_path=${STUB_DIR}:/etc/inc:/usr/local/share/pear" "${PHP_SCRIPT}" 2>/dev/null || true
+    rm -f "${PHP_SCRIPT}"
+    rm -rf "${STUB_DIR}"
 
     ok "Package deregistered"
 }
@@ -337,3 +391,8 @@ case "${COMMAND}" in
         ;;
 
 esac
+
+# ─── Cleanup downloaded source tree ──────────────────────────────────────────
+if [ "${REPO_DOWNLOADED}" -eq 1 ] && [ -d "${REPO_ROOT}" ]; then
+    rm -rf "${REPO_ROOT}"
+fi

--- a/install.sh
+++ b/install.sh
@@ -311,6 +311,8 @@ cmd_remove_files() {
     rm -rf /usr/local/pkg/xray
     rm -f  /usr/local/etc/rc.d/xray.sh
     rm -f  /etc/newsyslog.conf.d/xray.conf
+    rm -f  /var/log/xray-core.log
+    rm -f  /var/log/xray-watchdog.log
 
     ok "Package files removed"
 }


### PR DESCRIPTION
## Summary

- **install.sh**: auto-download repo archive when running as standalone `fetch` script (no git required); fix `services_dhcp.inc` bootstrap error on pfSense 2.8.1 using a stub file
- **xray.inc**: register `package`/`menu`/`service` entries in pfSense config on install so VPN→Xray menu appears without pkg-system; guard all `installedpackages` sub-keys with `is_array()` to handle empty XML tags on fresh installs; clean up all xray config keys on deinstall; use `mwexec_bg` in `xray_resync` to avoid 504 on save
- **xray-service-control.php**: detect `config_mode` from `custom_config` presence (connections store data only in `custom_config`, not in `config_mode` field); override inbound port/listen from instance settings in custom JSON (fixes port collision with multiple instances); return error exit code when Xray is disabled globally
- **xray-urltest.inc**, **xray-rotation.php**: same `config_mode` detection fix
- **xray-ifstats.php**: parse server address from `custom_config` JSON via local helper instead of raw `server_address` field
- **xray_edit.php**, **xray_instances.php**: use `xray_connection_server_label()` for server display; show alert on failed start/stop; stop instance before deleting
- **README.md**: prioritize one-line `fetch` install over git clone

## Test plan

- [x] Fresh install on pfSense 2.7.2 via `fetch install.sh | sh`
- [x] Fresh install on pfSense 2.8.1 via local copy
- [x] VPN → Xray menu appears after install
- [x] Instance starts with custom_config connection
- [x] Multiple instances on same connection use correct SOCKS5 ports
- [x] Uninstall fully cleans config.xml, files, cron, TUN interfaces