### PR TITLE
feat: support multiple subscription URLs per group

### DIFF
--- a/files/usr/local/pkg/xray/includes/xray.inc
+++ b/files/usr/local/pkg/xray/includes/xray.inc
@@ -242,6 +242,18 @@ function xray_delete_instance(string $uuid): void
     write_config('Xray: delete instance ' . $uuid);
 }
 
+// ─── Group helpers ────────────────────────────────────────────────────────────
+
+function xray_group_sub_urls(array $group): array
+{
+    if (isset($group['sub_urls']) && $group['sub_urls'] !== '') {
+        $lines = preg_split('/[\r\n]+/', $group['sub_urls']);
+        return array_values(array_filter(array_map('trim', $lines)));
+    }
+    $legacy = trim($group['sub_url'] ?? '');
+    return $legacy !== '' ? [$legacy] : [];
+}
+
 // ─── Group CRUD ──────────────────────────────────────────────────────────────
 
 function xray_get_groups(): array
@@ -693,7 +705,7 @@ function xray_bootstrap_default_group(): void
         'uuid'       => XRAY_DEFAULT_GROUP_UUID,
         'name'       => 'Default',
         'type'       => 'manual',
-        'sub_url'    => '',
+        'sub_urls'   => '',
         'autoupdate' => '',
     ]);
 

--- a/files/usr/local/pkg/xray/includes/xray_validate.inc
+++ b/files/usr/local/pkg/xray/includes/xray_validate.inc
@@ -114,11 +114,15 @@ function xray_validate_group(array $post, ?string $editUuid): void
     }
 
     if ($type === 'subscription') {
-        $subUrl = trim($post['sub_url'] ?? '');
-        if ($subUrl === '') {
-            $input_errors[] = 'Subscription URL is required for subscription groups.';
-        } elseif (!filter_var($subUrl, FILTER_VALIDATE_URL)) {
-            $input_errors[] = 'Subscription URL must be a valid URL.';
+        $lines = array_values(array_filter(array_map('trim', preg_split('/[\r\n]+/', $post['sub_urls'] ?? ''))));
+        if (empty($lines)) {
+            $input_errors[] = 'At least one subscription URL is required for subscription groups.';
+        } else {
+            foreach ($lines as $i => $url) {
+                if (!filter_var($url, FILTER_VALIDATE_URL)) {
+                    $input_errors[] = 'URL #' . ($i + 1) . ': "' . htmlspecialchars($url, ENT_QUOTES, 'UTF-8') . '" is not a valid URL.';
+                }
+            }
         }
     }
 }

--- a/files/usr/local/scripts/xray/xray-subscription-update.php
+++ b/files/usr/local/scripts/xray/xray-subscription-update.php
@@ -72,7 +72,8 @@ foreach ($subUrls as $subUrl) {
     );
 
     if ($curlRc !== 0 || empty($curlOut)) {
-        continue;
+        echo json_encode(['error' => 'Failed to fetch subscription URL: ' . $subUrl]) . "\n";
+        exit(1);
     }
 
     $raw = implode("\n", $curlOut);
@@ -87,8 +88,8 @@ foreach ($subUrls as $subUrl) {
         if (strpos($line, 'vless://') === 0) {
             $key = md5($line);
             if (!isset($seenKeys[$key])) {
-                $seenKeys[$key]  = true;
-                $fetchedLinks[]  = $line;
+                $seenKeys[$key] = true;
+                $fetchedLinks[] = $line;
             }
         }
     }

--- a/files/usr/local/scripts/xray/xray-subscription-update.php
+++ b/files/usr/local/scripts/xray/xray-subscription-update.php
@@ -44,39 +44,55 @@ if (($group['type'] ?? 'manual') !== 'subscription') {
     exit(1);
 }
 
-$subUrl = trim($group['sub_url'] ?? '');
-if ($subUrl === '') {
+$subUrls = [];
+if (isset($group['sub_urls']) && $group['sub_urls'] !== '') {
+    $subUrls = array_values(array_filter(array_map('trim', preg_split('/[\r\n]+/', $group['sub_urls']))));
+} elseif (($group['sub_url'] ?? '') !== '') {
+    $subUrls = [trim($group['sub_url'])];
+}
+
+if (empty($subUrls)) {
     echo json_encode(['error' => 'Subscription URL is empty']) . "\n";
     exit(1);
 }
 
 $curlBin = file_exists('/usr/local/bin/curl') ? '/usr/local/bin/curl' : '/usr/bin/curl';
 
-$curlOut = [];
-exec(
-    $curlBin . ' -s -L --max-time 30 -A "xray-pfsense/1.0"'
-    . ' ' . escapeshellarg($subUrl)
-    . ' 2>/dev/null',
-    $curlOut,
-    $curlRc
-);
+$fetchedLinks = [];
+$seenKeys     = [];
 
-if ($curlRc !== 0 || empty($curlOut)) {
-    echo json_encode(['error' => 'Failed to fetch subscription URL (exit ' . $curlRc . ')']) . "\n";
-    exit(1);
+foreach ($subUrls as $subUrl) {
+    $curlOut = [];
+    exec(
+        $curlBin . ' -s -L --max-time 30 -A "xray-pfsense/1.0"'
+        . ' ' . escapeshellarg($subUrl)
+        . ' 2>/dev/null',
+        $curlOut,
+        $curlRc
+    );
+
+    if ($curlRc !== 0 || empty($curlOut)) {
+        continue;
+    }
+
+    $raw = implode("\n", $curlOut);
+
+    $decoded = base64_decode(trim($raw), true);
+    if ($decoded !== false && strpos($decoded, 'vless://') !== false) {
+        $raw = $decoded;
+    }
+
+    $lines = array_filter(array_map('trim', preg_split('/[\r\n]+/', $raw)));
+    foreach ($lines as $line) {
+        if (strpos($line, 'vless://') === 0) {
+            $key = md5($line);
+            if (!isset($seenKeys[$key])) {
+                $seenKeys[$key]  = true;
+                $fetchedLinks[]  = $line;
+            }
+        }
+    }
 }
-
-$raw = implode("\n", $curlOut);
-
-$decoded = base64_decode(trim($raw), true);
-if ($decoded !== false && strpos($decoded, 'vless://') !== false) {
-    $raw = $decoded;
-}
-
-$lines = array_filter(array_map('trim', preg_split('/[\r\n]+/', $raw)));
-$fetchedLinks = array_values(array_filter($lines, static function (string $line): bool {
-    return strpos($line, 'vless://') === 0;
-}));
 
 if (empty($fetchedLinks)) {
     echo json_encode(['error' => 'No vless:// links found in subscription']) . "\n";

--- a/files/usr/local/www/xray/xray_ajax.php
+++ b/files/usr/local/www/xray/xray_ajax.php
@@ -291,7 +291,7 @@ switch ($action) {
         echo json_encode(['error' => 'Unknown action: ' . htmlspecialchars($action, ENT_QUOTES, 'UTF-8')]);
 }
 
-function xray_fetch_links_from_url(string $url): array
+function xray_fetch_links_from_url(string $url): array|false
 {
     $curlBin = file_exists('/usr/local/bin/curl') ? '/usr/local/bin/curl' : '/usr/bin/curl';
     $rawOut  = [];
@@ -304,7 +304,7 @@ function xray_fetch_links_from_url(string $url): array
     );
 
     if ($curlRc !== 0 || empty($rawOut)) {
-        return [];
+        return false;
     }
 
     $raw     = implode("\n", $rawOut);
@@ -337,11 +337,15 @@ function xray_ajax_update_subscription(string $groupUuid): array
     $fetchedLinks = [];
     $seenKeys     = [];
     foreach ($urls as $url) {
-        foreach (xray_fetch_links_from_url($url) as $link) {
+        $links = xray_fetch_links_from_url($url);
+        if ($links === false) {
+            return ['error' => 'Failed to fetch subscription URL: ' . $url];
+        }
+        foreach ($links as $link) {
             $key = md5($link);
             if (!isset($seenKeys[$key])) {
-                $seenKeys[$key]  = true;
-                $fetchedLinks[]  = $link;
+                $seenKeys[$key] = true;
+                $fetchedLinks[] = $link;
             }
         }
     }

--- a/files/usr/local/www/xray/xray_ajax.php
+++ b/files/usr/local/www/xray/xray_ajax.php
@@ -291,6 +291,34 @@ switch ($action) {
         echo json_encode(['error' => 'Unknown action: ' . htmlspecialchars($action, ENT_QUOTES, 'UTF-8')]);
 }
 
+function xray_fetch_links_from_url(string $url): array
+{
+    $curlBin = file_exists('/usr/local/bin/curl') ? '/usr/local/bin/curl' : '/usr/bin/curl';
+    $rawOut  = [];
+    exec(
+        $curlBin . ' -s -L --max-time 30 -A "xray-pfsense/1.0"'
+        . ' ' . escapeshellarg($url)
+        . ' 2>/dev/null',
+        $rawOut,
+        $curlRc
+    );
+
+    if ($curlRc !== 0 || empty($rawOut)) {
+        return [];
+    }
+
+    $raw     = implode("\n", $rawOut);
+    $decoded = base64_decode(trim($raw), true);
+    if ($decoded !== false && strpos($decoded, 'vless://') !== false) {
+        $raw = $decoded;
+    }
+
+    $lines = array_filter(array_map('trim', preg_split('/[\r\n]+/', $raw)));
+    return array_values(array_filter($lines, static function (string $line): bool {
+        return strpos($line, 'vless://') === 0;
+    }));
+}
+
 function xray_ajax_update_subscription(string $groupUuid): array
 {
     $group = xray_get_group_by_uuid($groupUuid);
@@ -301,35 +329,22 @@ function xray_ajax_update_subscription(string $groupUuid): array
         return ['error' => 'Group is not a subscription group'];
     }
 
-    $subUrl = trim($group['sub_url'] ?? '');
-    if ($subUrl === '') {
+    $urls = xray_group_sub_urls($group);
+    if (empty($urls)) {
         return ['error' => 'Subscription URL is empty'];
     }
 
-    $curlBin = file_exists('/usr/local/bin/curl') ? '/usr/local/bin/curl' : '/usr/bin/curl';
-    $rawOut  = [];
-    exec(
-        $curlBin . ' -s -L --max-time 30 -A "xray-pfsense/1.0"'
-        . ' ' . escapeshellarg($subUrl)
-        . ' 2>/dev/null',
-        $rawOut,
-        $curlRc
-    );
-
-    if ($curlRc !== 0 || empty($rawOut)) {
-        return ['error' => 'Failed to fetch subscription URL (curl exit ' . $curlRc . ')'];
+    $fetchedLinks = [];
+    $seenKeys     = [];
+    foreach ($urls as $url) {
+        foreach (xray_fetch_links_from_url($url) as $link) {
+            $key = md5($link);
+            if (!isset($seenKeys[$key])) {
+                $seenKeys[$key]  = true;
+                $fetchedLinks[]  = $link;
+            }
+        }
     }
-
-    $raw     = implode("\n", $rawOut);
-    $decoded = base64_decode(trim($raw), true);
-    if ($decoded !== false && strpos($decoded, 'vless://') !== false) {
-        $raw = $decoded;
-    }
-
-    $lines = array_filter(array_map('trim', preg_split('/[\r\n]+/', $raw)));
-    $fetchedLinks = array_values(array_filter($lines, static function (string $line): bool {
-        return strpos($line, 'vless://') === 0;
-    }));
 
     if (empty($fetchedLinks)) {
         return ['error' => 'No vless:// links found in subscription'];

--- a/files/usr/local/www/xray/xray_group_edit.php
+++ b/files/usr/local/www/xray/xray_group_edit.php
@@ -26,13 +26,20 @@ $isNew = ($editUuid === '');
 $defaults = [
     'name'       => '',
     'type'       => 'manual',
-    'sub_url'    => '',
+    'sub_urls'   => '',
     'autoupdate' => '',
 ];
 
 if (!$isNew) {
     $existing = xray_get_group_by_uuid($editUuid);
-    $pconfig  = $existing !== null ? array_merge($defaults, $existing) : $defaults;
+    if ($existing !== null) {
+        $pconfig = array_merge($defaults, $existing);
+        if (!isset($existing['sub_urls']) || $existing['sub_urls'] === '') {
+            $pconfig['sub_urls'] = implode("\n", xray_group_sub_urls($existing));
+        }
+    } else {
+        $pconfig = $defaults;
+    }
 } else {
     $pconfig = $defaults;
 }
@@ -48,11 +55,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['act']) && $_POST['act
         $type = in_array($_POST['type'] ?? '', ['manual', 'subscription'], true)
             ? $_POST['type'] : 'manual';
 
+        $subUrls = '';
+        if ($type === 'subscription') {
+            $rawLines = preg_split('/[\r\n]+/', $_POST['sub_urls'] ?? '');
+            $subUrls  = implode("\n", array_values(array_filter(array_map('trim', $rawLines))));
+        }
+
         $group = [
             'uuid'       => $newUuid,
             'name'       => trim($_POST['name'] ?? ''),
             'type'       => $type,
-            'sub_url'    => $type === 'subscription' ? trim($_POST['sub_url'] ?? '') : '',
+            'sub_urls'   => $subUrls,
             'autoupdate' => ($type === 'subscription' && !empty($_POST['autoupdate'])) ? 'on' : '',
         ];
 
@@ -62,7 +75,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['act']) && $_POST['act
         exit;
     }
 
-    $pconfig = array_merge($defaults, $_POST);
+    $pconfig         = array_merge($defaults, $_POST);
     $pconfig['uuid'] = $editUuid;
 }
 
@@ -107,13 +120,12 @@ $form->add($section);
 $sectionSub = new Form_Section(gettext('Subscription Settings'));
 $sectionSub->setAttribute('id', 'subscription-section');
 
-$sectionSub->addInput(new Form_Input(
-    'sub_url',
-    gettext('Subscription URL'),
-    'text',
-    $pconfig['sub_url'],
-    ['placeholder' => 'https://example.com/sub/...']
-))->setHelp(gettext('Remote URL returning a list of vless:// links (plain text or base64-encoded).'));
+$sectionSub->addInput(new Form_Textarea(
+    'sub_urls',
+    gettext('Subscription URLs'),
+    $pconfig['sub_urls'],
+    ['placeholder' => "https://provider1.example.com/sub/token1\nhttps://provider2.example.com/sub/token2", 'rows' => '4']
+))->setHelp(gettext('One URL per line. All URLs will be fetched and merged into a single pool of connections.'));
 
 $sectionSub->addInput(new Form_Checkbox(
     'autoupdate',


### PR DESCRIPTION
## Summary

- Replace single `sub_url` field with `sub_urls` textarea (one URL per line) in subscription groups
- Fetch and merge connections from all URLs into a single pool with deduplication
- Backward-compatible: existing groups with `sub_url` continue to work via migration helper `xray_group_sub_urls()`

## Changes

- `xray.inc` — added `xray_group_sub_urls()` helper (reads new `sub_urls` or falls back to legacy `sub_url`)
- `xray_validate.inc` — validates each URL in the list individually
- `xray_group_edit.php` — `Form_Textarea` replaces single `Form_Input` for subscription URLs
- `xray_ajax.php` — `update_subscription` now loops over all URLs and deduplicates links
- `xray-subscription-update.php` — same logic for the cron-based auto-update script

Closes #4