### PR TITLE
fix: require tun-prefixed interface names to prevent boot-time mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Ported from [os-xray](https://github.com/MrTheory/os-xray) (OPNsense plugin). Al
 xray-core  (VLESS+Reality outbound)
     ↓  SOCKS5  (127.0.0.1:10808, configurable)
 hev-socks5-tunnel  (amd64)  /  tun2socks  (aarch64 fallback)
-    ↓  TUN interface  (e.g. proxytun0)
+    ↓  TUN interface  (e.g. tunproxy0)
 pfSense Gateway  →  Firewall Rules  →  Selective routing
 ```
 
@@ -166,7 +166,7 @@ After updating, the connections list shows a ping result badge for each entry (r
 **VPN → Xray → Instances → Add Instance**
 
 1. Select a **Connection Group** — the instance will use connections from this group
-2. Set **TUN Interface** name (e.g. `proxytun0`) — must be unique per instance
+2. Set **TUN Interface** name (e.g. `tunproxy0`) — must be unique per instance
 3. Set **SOCKS5 Port** — must be unique per instance (default: `10808`)
 4. **Save** → **Start**
 
@@ -365,7 +365,7 @@ cat /usr/local/tun2socks/backend.txt
 ps aux | grep -E 'hev-socks5|tun2socks'
 
 # Check interface
-ifconfig proxytun0
+ifconfig tunproxy0
 ```
 
 **Gateway is marked down**

--- a/files/usr/local/pkg/xray/includes/xray_validate.inc
+++ b/files/usr/local/pkg/xray/includes/xray_validate.inc
@@ -68,8 +68,8 @@ function xray_validate_input(array $post, ?string $editUuid): void
     }
 
     $tunIface = trim($post['tun_interface'] ?? '');
-    if (!preg_match('/^[a-z][a-z0-9]{0,13}[0-9]$/', $tunIface)) {
-        $input_errors[] = 'TUN interface name must start with a lowercase letter, end with a digit, and be at most 15 characters (e.g. proxytun0).';
+    if (!preg_match('/^tun[a-z0-9]{1,10}[0-9]$/', $tunIface)) {
+        $input_errors[] = 'TUN interface name must start with "tun", end with a digit, and be at most 15 characters (e.g. tunproxy0).';
     } else {
         xray_validate_tun_unique($tunIface, $editUuid);
     }

--- a/files/usr/local/pkg/xray/includes/xray_validate.inc
+++ b/files/usr/local/pkg/xray/includes/xray_validate.inc
@@ -68,7 +68,7 @@ function xray_validate_input(array $post, ?string $editUuid): void
     }
 
     $tunIface = trim($post['tun_interface'] ?? '');
-    if (!preg_match('/^tun[a-z0-9]{1,10}[0-9]$/', $tunIface)) {
+    if (!preg_match('/^tun[a-z0-9]{0,11}[0-9]$/', $tunIface)) {
         $input_errors[] = 'TUN interface name must start with "tun", end with a digit, and be at most 15 characters (e.g. tunproxy0).';
     } else {
         xray_validate_tun_unique($tunIface, $editUuid);

--- a/files/usr/local/pkg/xray_validate.inc
+++ b/files/usr/local/pkg/xray_validate.inc
@@ -75,7 +75,7 @@ function xray_validate_input(array $post, ?string $editUuid): void
     }
 
     $tunIface = trim($post['tun_interface'] ?? '');
-    if (!preg_match('/^tun[a-z0-9]{1,10}[0-9]$/', $tunIface)) {
+    if (!preg_match('/^tun[a-z0-9]{0,11}[0-9]$/', $tunIface)) {
         $input_errors[] = 'TUN interface name must start with "tun", end with a digit, and be at most 15 characters (e.g. tunproxy0).';
     } else {
         xray_validate_tun_unique($tunIface, $editUuid);

--- a/files/usr/local/pkg/xray_validate.inc
+++ b/files/usr/local/pkg/xray_validate.inc
@@ -75,8 +75,8 @@ function xray_validate_input(array $post, ?string $editUuid): void
     }
 
     $tunIface = trim($post['tun_interface'] ?? '');
-    if (!preg_match('/^[a-z][a-z0-9]{0,13}[0-9]$/', $tunIface)) {
-        $input_errors[] = 'TUN interface name must start with a lowercase letter, end with a digit, and be at most 15 characters (e.g. proxytun0).';
+    if (!preg_match('/^tun[a-z0-9]{1,10}[0-9]$/', $tunIface)) {
+        $input_errors[] = 'TUN interface name must start with "tun", end with a digit, and be at most 15 characters (e.g. tunproxy0).';
     } else {
         xray_validate_tun_unique($tunIface, $editUuid);
     }

--- a/files/usr/local/scripts/xray/xray-ifstats.php
+++ b/files/usr/local/scripts/xray/xray-ifstats.php
@@ -43,7 +43,7 @@ if ($inst === null) {
     exit(1);
 }
 
-$tunIface  = $inst['tun_interface'] ?? 'proxytun0';
+$tunIface  = $inst['tun_interface'] ?? 'tunproxy0';
 $xrayPid   = "/var/run/xray_core_{$inst_uuid}.pid";
 $t2sPid    = "/var/run/tunnel_{$inst_uuid}.pid";
 

--- a/files/usr/local/scripts/xray/xray-service-control.php
+++ b/files/usr/local/scripts/xray/xray-service-control.php
@@ -158,7 +158,7 @@ function xray_parse_instance_array(array $inst, array $conn, bool $globalEnabled
         'custom_config'          => $conn['custom_config'] ?? '',
         'socks5_listen'          => ($inst['socks5_listen'] ?? '127.0.0.1') ?: '127.0.0.1',
         'socks5_port'            => (int)($inst['socks5_port'] ?? 10808) ?: 10808,
-        'tun_iface'              => $inst['tun_interface']       ?? 'proxytun0',
+        'tun_iface'              => $inst['tun_interface']       ?? 'tunproxy0',
         'mtu'                    => (int)($inst['mtu'] ?? 1500),
         'loglevel'               => $loglevel,
         'bypass_networks'        => ($inst['bypass_networks'] ?? '10.0.0.0/8,172.16.0.0/12,192.168.0.0/16')
@@ -650,7 +650,7 @@ function do_stop(string $inst_uuid, ?string $tunIface = null): void
 {
     if ($tunIface === null) {
         $c        = xray_get_config($inst_uuid);
-        $tunIface = $c['tun_iface'] ?? 'proxytun0';
+        $tunIface = $c['tun_iface'] ?? 'tunproxy0';
     }
 
     proc_kill(t2s_pid_path($inst_uuid));
@@ -872,7 +872,7 @@ switch ($action) {
     case 'restart':
         if ($inst_uuid !== '') {
             $c        = xray_get_config($inst_uuid);
-            $tunIface = $c['tun_iface'] ?? 'proxytun0';
+            $tunIface = $c['tun_iface'] ?? 'tunproxy0';
             do_stop($inst_uuid, $tunIface);
             sleep(1);
             if (!empty($c) && $c['enabled']) {
@@ -881,7 +881,7 @@ switch ($action) {
         } else {
             $all = xray_get_all_instances();
             foreach ($all as $uuid => $c) {
-                do_stop($uuid, $c['tun_iface'] ?? 'proxytun0');
+                do_stop($uuid, $c['tun_iface'] ?? 'tunproxy0');
             }
             sleep(1);
             foreach ($all as $uuid => $c) {
@@ -895,7 +895,7 @@ switch ($action) {
     case 'reconfigure':
         if ($inst_uuid !== '') {
             $c        = xray_get_config($inst_uuid);
-            $tunIface = $c['tun_iface'] ?? 'proxytun0';
+            $tunIface = $c['tun_iface'] ?? 'tunproxy0';
             do_stop($inst_uuid, $tunIface);
             sleep(1);
             if (!empty($c) && $c['enabled']) {
@@ -915,7 +915,7 @@ switch ($action) {
         $all       = xray_get_all_instances();
         $allStopped = [];
         foreach ($all as $uuid => $c) {
-            do_stop($uuid, $c['tun_iface'] ?? 'proxytun0');
+            do_stop($uuid, $c['tun_iface'] ?? 'tunproxy0');
             $allStopped[$uuid] = $c;
         }
         sleep(1);

--- a/files/usr/local/www/xray/xray_edit.php
+++ b/files/usr/local/www/xray/xray_edit.php
@@ -31,7 +31,7 @@ $defaults = [
     'webhook_url'            => '',
     'socks5_listen'          => '127.0.0.1',
     'socks5_port'            => '10808',
-    'tun_interface'          => 'proxytun0',
+    'tun_interface'          => 'tunproxy0',
     'mtu'                    => '1500',
     'loglevel'               => 'warning',
     'bypass_networks'        => '10.0.0.0/8,172.16.0.0/12,192.168.0.0/16',
@@ -233,8 +233,8 @@ $sectionNetwork->addInput(new Form_Input(
     gettext('*TUN Interface'),
     'text',
     $pconfig['tun_interface'],
-    ['placeholder' => 'proxytun0', 'maxlength' => '15']
-))->setHelp(gettext('Must start with a lowercase letter and end with a digit (e.g. proxytun0).'));
+    ['placeholder' => 'tunproxy0', 'maxlength' => '15']
+))->setHelp(gettext('Must start with "tun" and end with a digit (e.g. tunproxy0). This prefix is required so pfSense skips the interface during boot-time checks.'));
 
 $sectionNetwork->addInput(new Form_Input(
     'mtu',


### PR DESCRIPTION
## Problem

pfSense's `is_interface_mismatch()` checks every interface in `$config['interfaces']` for physical presence at boot time. It skips interfaces whose names match the regex `/^tun/` — since those are known virtual interfaces. The plugin was using `proxytun0` as the default name, which does **not** match `^tun`, so pfSense treated it as a missing physical interface and stopped boot with "Network interface mismatch".

## Fix

- Rename default interface name `proxytun0` → `tunproxy0`
- Enforce `/^tun/` prefix in validation — form now rejects any name that doesn't start with `tun`
- Updated placeholder, help text, and fallback defaults across all scripts

## Migration note

Users with existing instances named `proxytun0` (or any non-`tun`-prefixed name) will need to rename the TUN interface in the instance settings after upgrading. The old name will fail validation on next save.

Closes #7