### PR TITLE
fix: load if_tun kernel module on boot via kld_list

### DIFF
--- a/files/usr/local/pkg/xray.inc
+++ b/files/usr/local/pkg/xray.inc
@@ -209,6 +209,7 @@ EOT;
     file_put_contents('/etc/newsyslog.conf.d/xray.conf', $newsyslog . "\n");
 
     mwexec('/usr/sbin/sysrc -f /etc/rc.conf.local xray_enable=YES');
+    mwexec('/usr/sbin/sysrc -f /etc/rc.conf.local kld_list+=if_tun');
 
     install_cron_job(
         '/usr/local/bin/php /usr/local/scripts/xray/xray-watchdog.php',
@@ -238,6 +239,7 @@ function xray_deinstall(): void
     @unlink('/etc/newsyslog.conf.d/xray.conf');
 
     mwexec('/usr/sbin/sysrc -f /etc/rc.conf.local xray_enable=NO');
+    mwexec('/usr/sbin/sysrc -f /etc/rc.conf.local kld_list-=if_tun');
 
     install_cron_job(
         '/usr/local/bin/php /usr/local/scripts/xray/xray-watchdog.php',

--- a/files/usr/local/pkg/xray.inc
+++ b/files/usr/local/pkg/xray.inc
@@ -209,7 +209,12 @@ EOT;
     file_put_contents('/etc/newsyslog.conf.d/xray.conf', $newsyslog . "\n");
 
     mwexec('/usr/sbin/sysrc -f /etc/rc.conf.local xray_enable=YES');
-    mwexec('/usr/sbin/sysrc -f /etc/rc.conf.local kld_list+=if_tun');
+
+    $kldList = trim(shell_exec('/usr/sbin/sysrc -n -f /etc/rc.conf.local kld_list 2>/dev/null') ?? '');
+    if (!in_array('if_tun', preg_split('/\s+/', $kldList), true)) {
+        mwexec('/usr/sbin/sysrc -f /etc/rc.conf.local kld_list+=if_tun');
+        @file_put_contents('/var/db/xray_kld_if_tun_added', '1');
+    }
 
     install_cron_job(
         '/usr/local/bin/php /usr/local/scripts/xray/xray-watchdog.php',
@@ -239,7 +244,11 @@ function xray_deinstall(): void
     @unlink('/etc/newsyslog.conf.d/xray.conf');
 
     mwexec('/usr/sbin/sysrc -f /etc/rc.conf.local xray_enable=NO');
-    mwexec('/usr/sbin/sysrc -f /etc/rc.conf.local kld_list-=if_tun');
+
+    if (file_exists('/var/db/xray_kld_if_tun_added')) {
+        mwexec('/usr/sbin/sysrc -f /etc/rc.conf.local kld_list-=if_tun');
+        @unlink('/var/db/xray_kld_if_tun_added');
+    }
 
     install_cron_job(
         '/usr/local/bin/php /usr/local/scripts/xray/xray-watchdog.php',


### PR DESCRIPTION
## Problem

After power loss, pfSense drops into interactive interface assignment mode because `tunproxyN` interfaces are registered in `config.xml` but the `if_tun` kernel module is not loaded yet when pfSense initializes interfaces at boot.

## Solution

Register `if_tun` in `kld_list` via `rc.conf.local` during package install — FreeBSD loads it before network interface initialization.

- `xray_install()`: `sysrc kld_list+=if_tun` — appends to the list, preserves other values
- `xray_deinstall()`: `sysrc kld_list-=if_tun` — removes only `if_tun`, preserves other values

## Test plan

- [x] Install package, reboot — pfSense should boot normally without interactive prompt
- [x] Uninstall package — `if_tun` should be removed from `kld_list` in `rc.conf.local`
- [x] If other modules are in `kld_list`, verify they are not affected by install/uninstall